### PR TITLE
[VL-57] Pipeline to build and push container image

### DIFF
--- a/.github/workflows/build_push_image.yaml
+++ b/.github/workflows/build_push_image.yaml
@@ -1,0 +1,60 @@
+name: Build container image and maybe push it to the registry
+on:
+  workflow_call:
+    # Parameters of the workflow
+    inputs:
+      registry:
+        description: 'The registry to use. Default: ghcr.io'
+        type: string
+        required: false
+        default: 'ghcr.io'
+      image_name:
+        description: 'The name of the image.'
+        type: string
+        required: true
+      push:
+        description: 'If true, push the image to the registry. Default: false'
+        type: boolean
+        required: false
+        default: false
+    secrets:
+      token:
+        description: 'The token to use for authentication.'
+        required: true
+
+jobs:
+  reusable_workflow_job:
+    runs-on: ubuntu-latest
+
+    # Sets the permissions granted to the GITHUB_TOKEN for the actions in this job.
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      # https://github.com/docker/login-action#github-container-registry
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ inputs.registry }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.token }}
+
+      # https://github.com/docker/metadata-action#tags-input
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ inputs.registry }}/${{ inputs.image_name }}
+
+      # https://github.com/docker/build-push-action
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: ${{ inputs.push }}
+          tags: ${{ steps.meta.outputs.tags }}
+

--- a/.github/workflows/build_push_image.yaml
+++ b/.github/workflows/build_push_image.yaml
@@ -1,25 +1,24 @@
-name: Build container image and maybe push it to the registry
+name: Build container image and push it to the container registry, according to the value of the push parameter
 on:
   workflow_call:
-    # Parameters of the workflow
     inputs:
       registry:
-        description: 'The registry to use. Default: ghcr.io'
+        description: 'The container registry to use. Default: ghcr.io'
         type: string
         required: false
         default: 'ghcr.io'
       image_name:
-        description: 'The name of the image.'
+        description: 'The name of the container image.'
         type: string
         required: true
       push:
-        description: 'If true, push the image to the registry. Default: false'
+        description: 'If true, push the container image to the container registry. Default: false'
         type: boolean
         required: false
         default: false
     secrets:
       token:
-        description: 'The token to use for authentication.'
+        description: 'The token to use for authentication against the container registry.'
         required: true
 
 jobs:
@@ -51,7 +50,7 @@ jobs:
           images: ${{ inputs.registry }}/${{ inputs.image_name }}
 
       # https://github.com/docker/build-push-action
-      - name: Build and push Docker image
+      - name: Build and push container image
         uses: docker/build-push-action@v3
         with:
           context: .

--- a/.github/workflows/build_push_image.yaml
+++ b/.github/workflows/build_push_image.yaml
@@ -47,7 +47,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.token }}
 
-      # https://github.com/docker/metadata-action#tags-input
+      # https://github.com/docker/metadata-action
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v4

--- a/.github/workflows/build_push_image.yaml
+++ b/.github/workflows/build_push_image.yaml
@@ -16,13 +16,18 @@ on:
         type: boolean
         required: false
         default: false
+    outputs:
+      full_image_name:
+        description: 'The full container image name, containing the registry, the image name and the version.'
+        value: ${{ inputs.registry }}/${{ inputs.image_name }}:${{ jobs.build_push_image.steps.meta.outputs.version }}
     secrets:
       token:
         description: 'The token to use for authentication against the container registry.'
         required: true
 
 jobs:
-  reusable_workflow_job:
+  build_push_image:
+    name: Build container image and push it to the container registry (if push parameter is true)
     runs-on: ubuntu-latest
 
     # Sets the permissions granted to the GITHUB_TOKEN for the actions in this job.

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   build_image:
     name: Build the container image
-    uses: pagopa/pn-local-emulator/.github/workflows/build_push_image.yaml@features/cd-docker-image
+    uses: ./.github/workflows/build_push_image.yaml
     with:
       image_name: ${{ github.repository }}
     secrets:
@@ -19,7 +19,7 @@ jobs:
     name: Scan for vulnerabilities
     needs:
       - build_image
-    uses: pagopa/pn-local-emulator/.github/workflows/trivy.yaml@features/cd-docker-image
+    uses: ./.github/workflows/trivy.yaml
     with:
       container_image_name: ${{ needs.build_image.outputs.full_image_name }}
 
@@ -27,7 +27,7 @@ jobs:
     name: Push the container image to the container registry
     needs:
       - vulnerabilities_scan
-    uses: pagopa/pn-local-emulator/.github/workflows/build_push_image.yaml@features/cd-docker-image
+    uses: ./.github/workflows/build_push_image.yaml
     with:
       image_name: ${{ github.repository }}
       push: true

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -6,7 +6,24 @@ on:
       - '*' # Create container image and publish it on tag creation
 
 jobs:
+  build_image:
+    uses: pagopa/pn-local-emulator-poc/.github/workflows/build_push_image.yaml@features/cd-docker-image
+    with:
+      image_name: ${{ github.repository }}
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}
+
+  vulnerabilities_scan:
+    name: Scan for vulnerabilities
+    needs:
+      - build_image
+    uses: pagopa/pn-local-emulator-poc/.github/workflows/trivy.yaml@features/cd-docker-image
+    with:
+      container_image_name: ${{ needs.build_image.outputs.full_image_name }}
+
   push_image:
+    needs:
+      - vulnerabilities_scan
     uses: pagopa/pn-local-emulator-poc/.github/workflows/build_push_image.yaml@features/cd-docker-image
     with:
       image_name: ${{ github.repository }}

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -3,8 +3,7 @@ name: Create and publish a container image
 on:
   push:
     tags:
-      # https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
-      - '^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$'
+      - '*'
 
 jobs:
   build_image:

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   build_image:
+    name: Build the container image
     uses: pagopa/pn-local-emulator-poc/.github/workflows/build_push_image.yaml@features/cd-docker-image
     with:
       image_name: ${{ github.repository }}
@@ -22,6 +23,7 @@ jobs:
       container_image_name: ${{ needs.build_image.outputs.full_image_name }}
 
   push_image:
+    name: Push the container image to the container registry
     needs:
       - vulnerabilities_scan
     uses: pagopa/pn-local-emulator-poc/.github/workflows/build_push_image.yaml@features/cd-docker-image

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -1,0 +1,15 @@
+name: Create and publish a container image
+
+on:
+  push:
+    tags:
+      - '*' # Create container image and publish it on tag creation
+
+jobs:
+  push_image:
+    uses: pagopa/pn-local-emulator-poc/.github/workflows/build_push_image.yaml@main
+    with:
+      image_name: ${{ github.repository }}
+      push: true
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   push_image:
-    uses: pagopa/pn-local-emulator-poc/.github/workflows/build_push_image.yaml@main
+    uses: pagopa/pn-local-emulator-poc/.github/workflows/build_push_image.yaml@features/cd-docker-image
     with:
       image_name: ${{ github.repository }}
       push: true

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   build_image:
     name: Build the container image
-    uses: pagopa/pn-local-emulator-poc/.github/workflows/build_push_image.yaml@features/cd-docker-image
+    uses: pagopa/pn-local-emulator/.github/workflows/build_push_image.yaml@features/cd-docker-image
     with:
       image_name: ${{ github.repository }}
     secrets:
@@ -18,7 +18,7 @@ jobs:
     name: Scan for vulnerabilities
     needs:
       - build_image
-    uses: pagopa/pn-local-emulator-poc/.github/workflows/trivy.yaml@features/cd-docker-image
+    uses: pagopa/pn-local-emulator/.github/workflows/trivy.yaml@features/cd-docker-image
     with:
       container_image_name: ${{ needs.build_image.outputs.full_image_name }}
 
@@ -26,7 +26,7 @@ jobs:
     name: Push the container image to the container registry
     needs:
       - vulnerabilities_scan
-    uses: pagopa/pn-local-emulator-poc/.github/workflows/build_push_image.yaml@features/cd-docker-image
+    uses: pagopa/pn-local-emulator/.github/workflows/build_push_image.yaml@features/cd-docker-image
     with:
       image_name: ${{ github.repository }}
       push: true

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -3,7 +3,8 @@ name: Create and publish a container image
 on:
   push:
     tags:
-      - '*' # Create container image and publish it on tag creation
+      # https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
+      - '^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$'
 
 jobs:
   build_image:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,7 +34,7 @@ jobs:
     name: Build the container image
     needs:
       - build
-    uses: pagopa/pn-local-emulator-poc/.github/workflows/build_push_image.yaml@features/cd-docker-image
+    uses: pagopa/pn-local-emulator/.github/workflows/build_push_image.yaml@features/cd-docker-image
     with:
       image_name: ${{ github.repository }}
       push: false

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,6 +43,6 @@ jobs:
     name: Scan for vulnerabilities
     needs:
       - build_image
-    uses: pagopa/pn-local-emulator-poc/.github/workflows/trivy.yml@features/cd-docker-image
+    uses: pagopa/pn-local-emulator-poc/.github/workflows/trivy.yaml@features/cd-docker-image
     with:
       container_image: ${{ needs.build_image.outputs.full_image_name }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,11 +38,3 @@ jobs:
       push: false
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}
-
-  vulnerabilities_scan:
-    name: Scan for vulnerabilities
-    needs:
-      - build_image
-    uses: pagopa/pn-local-emulator-poc/.github/workflows/trivy.yaml@features/cd-docker-image
-    with:
-      container_image_name: ${{ needs.build_image.outputs.full_image_name }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,4 +45,4 @@ jobs:
       - build_image
     uses: pagopa/pn-local-emulator-poc/.github/workflows/trivy.yaml@features/cd-docker-image
     with:
-      container_image: ${{ needs.build_image.outputs.full_image_name }}
+      container_image_name: ${{ needs.build_image.outputs.full_image_name }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,3 +38,11 @@ jobs:
       push: false
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}
+
+  vulnerabilities_scan:
+    name: Scan for vulnerabilities
+    needs:
+      - build_image
+    uses: pagopa/pn-local-emulator-poc/.github/workflows/trivy.yml@features/cd-docker-image
+    with:
+      container_image: ${{ needs.build_image.outputs.full_image_name }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,7 @@ on: pull_request
 
 jobs:
   build:
+    name: Compile and test
     runs-on: ubuntu-latest
 
     steps:
@@ -30,6 +31,7 @@ jobs:
         run: npm test
 
   build_image:
+    name: Build the container image
     needs:
       - build
     uses: pagopa/pn-local-emulator-poc/.github/workflows/build_push_image.yaml@features/cd-docker-image

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,7 +34,7 @@ jobs:
     name: Build the container image
     needs:
       - build
-    uses: ./.github/workflows/actions/build_push_image.yaml
+    uses: ./.github/workflows/build_push_image.yaml
     with:
       image_name: ${{ github.repository }}
       push: false

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,7 +32,7 @@ jobs:
   build_image:
     needs:
       - build
-    uses: pagopa/pn-local-emulator-poc/.github/workflows/build_push_image.yaml@main
+    uses: pagopa/pn-local-emulator-poc/.github/workflows/build_push_image.yaml@features/cd-docker-image
     with:
       image_name: ${{ github.repository }}
       push: false

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,3 +28,13 @@ jobs:
 
       - name: Execute tests
         run: npm test
+
+  build_image:
+    needs:
+      - build
+    uses: pagopa/pn-local-emulator-poc/.github/workflows/build_push_image.yaml@main
+    with:
+      image_name: ${{ github.repository }}
+      push: false
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,7 +34,7 @@ jobs:
     name: Build the container image
     needs:
       - build
-    uses: pagopa/pn-local-emulator/.github/workflows/build_push_image.yaml@features/cd-docker-image
+    uses: ./.github/workflows/actions/build_push_image.yaml
     with:
       image_name: ${{ github.repository }}
       push: false

--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -16,7 +16,7 @@ jobs:
     permissions:
       contents: read
       security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
-    name: Build
+    name: Check for vulnerabilities using Trivy
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -1,0 +1,38 @@
+name: Check for vulnerabilities using Trivy
+
+on:
+  workflow_call:
+    inputs:
+      container_image_name:
+        description: 'The full container image name, containing the registry, the image name and the version.'
+        type: string
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    permissions:
+      contents: read
+      security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@0.7.1
+        with:
+          image-ref: ${{ inputs.container_image_name }}
+          format: 'template'
+          template: '@/contrib/sarif.tpl'
+          output: 'trivy-results.sarif'
+          severity: 'CRITICAL,HIGH'
+          security-checks: 'vuln,secret,config'
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -12,12 +12,15 @@ permissions:
   contents: read
 
 jobs:
-  build:
+  vulnerabilities_scan:
+
     permissions:
       contents: read
       security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
+      
     name: Check for vulnerabilities using Trivy
     runs-on: ubuntu-latest
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -1,66 +1,82 @@
-# PnValidator [![CI](https://github.com/pagopa/pn-local-emulator-poc/actions/workflows/ci.yaml/badge.svg)](https://github.com/pagopa/pn-local-emulator-poc/actions/workflows/ci.yaml)
+# PnValidator
+[![CI](https://github.com/pagopa/pn-local-emulator/actions/workflows/ci.yaml/badge.svg)](https://github.com/pagopa/pn-local-emulator/actions/workflows/ci.yaml)
 
-A system that emulates some features of Piattaforma Notifiche platform.
+A system that emulates some features of the Piattaforma Notifiche platform.
 
-## Generate the code
+## Prerequisites
+If you want to run the emulator locally, starting from the source code, you need to follow the next steps.
 
-Some code is generated from `openapi/index.yaml` file, the first time and when the content of `openapi/index.yaml` changes you should run the following command:
+The first thing to do is to clone the repository using the preferred method (the next command uses SSH):
 
-``` sh
-npm run generate
+```shell
+git clone git@github.com:pagopa/pn-local-emulator.git
 ```
+
+This project runs using [Node.js](https://nodejs.org/en/) and it has been developed with the version specified in the [`.node_version`](.node-version) file.
+
+You could [install nvm](https://github.com/nvm-sh/nvm) and use the next commands to install and set the same version
+of Node.js specified in the `.node_version` file.
+
+```shell
+# Install the version of Node.js specified in the .node_version file
+nvm install `cat .node-version`
+
+# Set the version of Node.js specified in the .node_version file
+nvm use `cat .node-version`
+```
+Make sure that the path of `.node_version` is correct because the example commands assume you are in the repository folder.
 
 ## How to run
 
-To run the tool run the following command:
+### Run using Node.js
 
-``` sh
-# if needed run generate
+Install the dependencies.
+
+```shell
+npm install
+```
+
+Generates code from the [OpenAPI](./openapi/index.yaml) specification.
+
+```shell
 npm run generate
+```
 
-# start the application
+Start the application.
+
+```shell
 npm run start
 ```
 
-## Run with Docker
+### Run using Docker (Dockerfile)
 
 The repository comes with a Dockerfile that you can use to run the application with Docker.
-First, build the image:
 
-``` sh
+Build the image.
+
+```shell
 docker build -t pnemulator .
 ```
 
-Then, run the application:
+Run the emulator.
 
-``` sh
+```shell
 docker run -p 3000:3000 pnemulator
 ```
+The [Dockerfile](./Dockerfile) exposes port `3000` of the container, so you can use the `-p` option to map it to a port of your choice.
 
-### Example
+### Run using the public container image
 
-``` sh
-# Get the report, initially it shows all 'ko'
-curl --location --request GET 'localhost:8080/checklistresult'
+Another option is to run the container image available in the container registry.
 
-# Require an upload slot
-curl --request POST 'http://localhost:8080/delivery/attachments/preload' \
---header 'x-api-key: key-value' \
---header 'Content-Type: application/json' \
---data-raw '[
-    {
-        "preloadIdx": "1",
-        "contentType": "application/pdf",
-        "sha256": "jezIVxlG1M1woCSUngM6KipUN3/a8cG5RMIPnuEanlE="
-    },
-    {
-        "preloadIdx": "2",
-        "contentType": "application/pdf",
-        "sha256": "jezIVxlG1M1woCSUngM6KipUN3/a8cG5RMIPnuEanlE="
-    }
-]'
+Pull the image from the container registry.
 
-# Get the report, as you can see some result are 'ok'
-curl --location --request GET 'localhost:8080/checklistresult'
+```shell
+docker pull ghcr.io/pagopa/pn-local-emulator:latest
+```
 
+Run the application.
+
+```shell
+docker run -p 3000:3000 ghcr.io/pagopa/pn-local-emulator:latest
 ```


### PR DESCRIPTION
This PR aims to create a pipeline that builds and then pushes a container image to a selected container registry.
As shown in #25, the container registry chosen is GitHub Packages, so this pipeline will build the image and then push it to GitHub Packages.

#### List of Changes
- Create a reusable workflow that builds and pushes a container image to a container registry
- Create the CD pipeline that pushes the container image to GitHub Packages
- Update the CI pipeline by adding the build of the image (without pushing it to the container registry)

#### Motivation and Context
We want to make sure that every time the CI is triggered, it checks that the container image is successfully built as well.
Moreover, a new pipeline automatically builds and pushes the container image to the selected container registry.

#### Types of changes
- [x] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
