### PR TITLE
[VL-66] - Error 403 on invalid API key

### DIFF
--- a/src/adapters/http/Problem.ts
+++ b/src/adapters/http/Problem.ts
@@ -12,6 +12,6 @@ export const fromNumber = (statusCode: number): Problem => ({
   type: `https://www.webfx.com/web-development/glossary/http-status-codes/what-is-a-${statusCode}-status-code/`,
   // TODO: fix this bad cast
   status: statusCode as never,
-  title: '${statusCode}',
+  title: `${statusCode}`,
   errors: [],
 });

--- a/src/domain/CheckNotificationStatusRepository.ts
+++ b/src/domain/CheckNotificationStatusRepository.ts
@@ -4,7 +4,7 @@ import { PaProtocolNumber } from '../generated/definitions/PaProtocolNumber';
 import { IdempotenceToken } from '../generated/definitions/IdempotenceToken';
 import { NotificationRequestId } from '../generated/definitions/NotificationRequestId';
 import { Repository } from './Repository';
-import { Response } from './types';
+import { Response, UnauthorizedMessageBody } from './types';
 import { NewNotificationRecord } from './NewNotificationRepository';
 
 export type CheckNotificationStatusRecord = {
@@ -12,7 +12,7 @@ export type CheckNotificationStatusRecord = {
   input:
     | { paProtocolNumber: PaProtocolNumber; idempotenceToken?: IdempotenceToken }
     | { notificationRequestId: NotificationRequestId };
-  output: Response<200, NewNotificationRequestStatusResponse> | Response<401> | Response<404>;
+  output: Response<200, NewNotificationRequestStatusResponse> | Response<403, UnauthorizedMessageBody> | Response<404>;
 };
 
 export const makeNewNotificationRequestStatusResponse = (

--- a/src/domain/CreateEventStreamRecordRepository.ts
+++ b/src/domain/CreateEventStreamRecordRepository.ts
@@ -2,12 +2,12 @@ import { ApiKey } from '../generated/definitions/ApiKey';
 import { StreamCreationRequest } from '../generated/streams/StreamCreationRequest';
 import { StreamMetadataResponse } from '../generated/streams/StreamMetadataResponse';
 import { Repository } from './Repository';
-import { Response } from './types';
+import { Response, UnauthorizedMessageBody } from './types';
 
 export type CreateEventStreamRecord = {
   type: 'CreateEventStreamRecord';
   input: { apiKey: ApiKey; body: StreamCreationRequest };
-  output: Response<200, StreamMetadataResponse> | Response<401>;
+  output: Response<200, StreamMetadataResponse> | Response<403, UnauthorizedMessageBody>;
 };
 
 export type CreateEventStreamRecordRepository = Repository<CreateEventStreamRecord>;

--- a/src/domain/NewNotificationRepository.ts
+++ b/src/domain/NewNotificationRepository.ts
@@ -2,12 +2,12 @@ import { ApiKey } from '../generated/definitions/ApiKey';
 import { NewNotificationRequest } from '../generated/definitions/NewNotificationRequest';
 import { NewNotificationResponse } from '../generated/definitions/NewNotificationResponse';
 import { Repository } from './Repository';
-import { Response } from './types';
+import { Response, UnauthorizedMessageBody } from './types';
 
 export type NewNotificationRecord = {
   type: 'NewNotificationRecord';
   input: { apiKey: ApiKey; body: NewNotificationRequest };
-  output: Response<202, NewNotificationResponse> | Response<401>;
+  output: Response<202, NewNotificationResponse> | Response<403, UnauthorizedMessageBody>;
 };
 
 export const makeNewNotificationResponse =

--- a/src/domain/PreLoadRepository.ts
+++ b/src/domain/PreLoadRepository.ts
@@ -4,12 +4,12 @@ import { ApiKey } from '../generated/definitions/ApiKey';
 import { PreLoadRequest } from '../generated/definitions/PreLoadRequest';
 import { HttpMethodEnum, PreLoadResponse } from '../generated/definitions/PreLoadResponse';
 import { Repository } from './Repository';
-import { Response } from './types';
+import { Response, UnauthorizedMessageBody } from './types';
 
 export type PreLoadRecord = {
   type: 'PreLoadRecord';
   input: { apiKey: ApiKey; body: PreLoadRequestBody };
-  output: Response<200, PreLoadResponseBody> | Response<401>;
+  output: Response<200, PreLoadResponseBody> | Response<403, UnauthorizedMessageBody>;
 };
 
 export const makePreLoadResponse = (

--- a/src/domain/authorize.ts
+++ b/src/domain/authorize.ts
@@ -1,14 +1,18 @@
 import * as E from 'fp-ts/lib/Either';
 import { pipe } from 'fp-ts/lib/function';
 import { ApiKey } from '../generated/definitions/ApiKey';
-import { Response } from './types';
+import { UnauthorizedMessageBody, Response } from './types';
 
-export const authorizeApiKey = (apiKey: ApiKey): E.Either<Response<401>, ApiKey> =>
+export const unauthorizedMessage: UnauthorizedMessageBody = {
+  message: 'User is not authorized to access this resource with an explicit deny',
+};
+
+export const authorizeApiKey = (apiKey: ApiKey): E.Either<Response<403, UnauthorizedMessageBody>, ApiKey> =>
   pipe(
     apiKey,
     E.fromPredicate(
       // TODO: Get "key-value" from configuration
       () => apiKey === 'key-value',
-      () => ({ statusCode: 401 as const, returned: undefined })
+      () => ({ statusCode: 403 as const, returned: unauthorizedMessage })
     )
   );

--- a/src/domain/authorize.ts
+++ b/src/domain/authorize.ts
@@ -1,11 +1,7 @@
 import * as E from 'fp-ts/lib/Either';
 import { pipe } from 'fp-ts/lib/function';
 import { ApiKey } from '../generated/definitions/ApiKey';
-import { UnauthorizedMessageBody, Response } from './types';
-
-export const unauthorizedMessage: UnauthorizedMessageBody = {
-  message: 'User is not authorized to access this resource with an explicit deny',
-};
+import { Response, UnauthorizedMessageBody, unauthorizedResponse } from './types';
 
 export const authorizeApiKey = (apiKey: ApiKey): E.Either<Response<403, UnauthorizedMessageBody>, ApiKey> =>
   pipe(
@@ -13,6 +9,6 @@ export const authorizeApiKey = (apiKey: ApiKey): E.Either<Response<403, Unauthor
     E.fromPredicate(
       // TODO: Get "key-value" from configuration
       () => apiKey === 'key-value',
-      () => ({ statusCode: 403 as const, returned: unauthorizedMessage })
+      () => unauthorizedResponse
     )
   );

--- a/src/domain/checklist/__tests__/preLoadChecklist.test.ts
+++ b/src/domain/checklist/__tests__/preLoadChecklist.test.ts
@@ -1,7 +1,7 @@
 import { PreLoadRecord } from '../../PreLoadRepository';
 import { evalCheck, Group } from '../types';
 import { check0, check1, check2, check3 } from '../preLoadChecklist';
-import { unauthorizedMessage } from '../../authorize';
+import { unauthorizedResponse } from '../../types';
 
 const basePreloadRecord: PreLoadRecord = {
   type: 'PreLoadRecord',
@@ -19,7 +19,7 @@ describe('preLoadChecklist', () => {
     const actualOK = check([
       {
         ...basePreloadRecord,
-        output: { ...basePreloadRecord.output, statusCode: 403, returned: unauthorizedMessage },
+        output: { ...basePreloadRecord.output, statusCode: 403, returned: unauthorizedResponse.returned },
       },
     ]);
     expect(actualOK.result).toStrictEqual('ok');

--- a/src/domain/checklist/__tests__/preLoadChecklist.test.ts
+++ b/src/domain/checklist/__tests__/preLoadChecklist.test.ts
@@ -1,6 +1,7 @@
 import { PreLoadRecord } from '../../PreLoadRepository';
 import { evalCheck, Group } from '../types';
 import { check0, check1, check2, check3 } from '../preLoadChecklist';
+import { unauthorizedMessage } from '../../authorize';
 
 const basePreloadRecord: PreLoadRecord = {
   type: 'PreLoadRecord',
@@ -12,11 +13,14 @@ describe('preLoadChecklist', () => {
   const group: Group = { name: 'The preload request' };
   const basePreloadDoc = { preloadIdx: '0', contentType: 'application/pdf', sha256: 'a-sha256' };
 
-  it('should exists a response with status code 401', () => {
+  it('should exists a response with status code 403', () => {
     const check = evalCheck({ ...check0, group });
 
     const actualOK = check([
-      { ...basePreloadRecord, output: { ...basePreloadRecord.output, statusCode: 401, returned: undefined } },
+      {
+        ...basePreloadRecord,
+        output: { ...basePreloadRecord.output, statusCode: 403, returned: unauthorizedMessage },
+      },
     ]);
     expect(actualOK.result).toStrictEqual('ok');
     const actualKO = check([{ ...basePreloadRecord }]);

--- a/src/domain/checklist/preLoadChecklist.ts
+++ b/src/domain/checklist/preLoadChecklist.ts
@@ -6,8 +6,8 @@ import { PreLoadRecord } from '../PreLoadRepository';
 import { Checklist } from './types';
 
 export const check0 = {
-  name: 'Exists a response with status code 401',
-  eval: RA.some((record: PreLoadRecord) => record.output.statusCode === 401),
+  name: 'Exists a response with status code 403',
+  eval: RA.some((record: PreLoadRecord) => record.output.statusCode === 403),
 };
 export const check1 = {
   name: 'Contains an api-key',

--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -1,11 +1,20 @@
 export type StatusCode = 200 | 202 | 403 | 404;
 
+// TODO: This should be generated from the OpenAPI spec
+export type UnauthorizedMessageBody = {
+  message: string;
+};
+
+const unauthorizedMessage: UnauthorizedMessageBody = {
+  message: 'User is not authorized to access this resource with an explicit deny',
+};
+
 export type Response<A extends StatusCode, B = void> = {
   statusCode: A;
   returned: B;
 };
 
-// TODO: This should be generated from the OpenAPI spec
-export type UnauthorizedMessageBody = {
-  message: string;
+export const unauthorizedResponse: Response<403, UnauthorizedMessageBody> = {
+  statusCode: 403,
+  returned: unauthorizedMessage,
 };

--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -1,4 +1,4 @@
-export type StatusCode = 200 | 202 | 401 | 404;
+export type StatusCode = 200 | 202 | 403 | 404;
 
 export type Response<A extends StatusCode, B = void> = {
   statusCode: A;

--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -5,6 +5,7 @@ export type Response<A extends StatusCode, B = void> = {
   returned: B;
 };
 
+// TODO: This should be generated from the OpenAPI spec
 export type UnauthorizedMessageBody = {
   message: string;
 };

--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -4,3 +4,7 @@ export type Response<A extends StatusCode, B = void> = {
   statusCode: A;
   returned: B;
 };
+
+export type UnauthorizedMessageBody = {
+  message: string;
+};

--- a/src/useCases/__tests__/CreateEventStreamUseCase.test.ts
+++ b/src/useCases/__tests__/CreateEventStreamUseCase.test.ts
@@ -4,7 +4,7 @@ import * as inMemory from '../../adapters/inMemory';
 import { makeLogger } from '../../logger';
 import * as data from '../../domain/__tests__/data';
 import { CreateEventStreamRecord } from '../../domain/CreateEventStreamRecordRepository';
-import { unauthorizedMessage } from '../../domain/authorize';
+import { unauthorizedResponse } from '../../domain/types';
 
 describe('CreateEventStreamUseCase', () => {
   it('should return 200', async () => {
@@ -23,6 +23,6 @@ describe('CreateEventStreamUseCase', () => {
 
     const actual = await useCase('invalid-api-key')(data.createEventStreamRecord.input.body)();
 
-    expect(actual).toStrictEqual(E.right({ statusCode: 403, returned: unauthorizedMessage }));
+    expect(actual).toStrictEqual(E.right(unauthorizedResponse));
   });
 });

--- a/src/useCases/__tests__/CreateEventStreamUseCase.test.ts
+++ b/src/useCases/__tests__/CreateEventStreamUseCase.test.ts
@@ -4,6 +4,7 @@ import * as inMemory from '../../adapters/inMemory';
 import { makeLogger } from '../../logger';
 import * as data from '../../domain/__tests__/data';
 import { CreateEventStreamRecord } from '../../domain/CreateEventStreamRecordRepository';
+import { unauthorizedMessage } from '../../domain/authorize';
 
 describe('CreateEventStreamUseCase', () => {
   it('should return 200', async () => {
@@ -17,11 +18,11 @@ describe('CreateEventStreamUseCase', () => {
 
     expect(actual).toStrictEqual(E.right(data.createEventStreamRecord.output));
   });
-  it('should return 401', async () => {
+  it('should return 403', async () => {
     const useCase = CreateEventStreamUseCase(inMemory.makeRepository(makeLogger())<CreateEventStreamRecord>([]));
 
     const actual = await useCase('invalid-api-key')(data.createEventStreamRecord.input.body)();
 
-    expect(actual).toStrictEqual(E.right({ statusCode: 401, returned: undefined }));
+    expect(actual).toStrictEqual(E.right({ statusCode: 403, returned: unauthorizedMessage }));
   });
 });


### PR DESCRIPTION
The PN system returns the error 
```
HTTP/1.1 403 Forbidden
{
    "message": "User is not authorized to access this resource with an explicit deny"
}
```
on requests with invalid API key, but the emulator returns a 401 error.

#### List of Changes
- Changed the status code when the API key is not valid
- Add the message body to requests that fail with 403

#### Motivation and Context
We have to keep aligned the emulator and the PN system

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
