### PR TITLE
[VL-134] - Compute SHA256 of uploaded document

### DIFF
--- a/src/adapters/http/uploadToS3/router.ts
+++ b/src/adapters/http/uploadToS3/router.ts
@@ -21,6 +21,7 @@ const handler =
       E.ap(t.union([t.undefined, AmzSdkChecksumAlg]).decode(req.headers['x-amz-sdk-checksum-algorithm'])),
       E.ap(AmzMetaSecret.decode(req.headers['x-amz-meta-secret'])),
       E.ap(AmzChecksumSHA256.decode(req.headers['x-amz-checksum-sha256'])),
+      E.ap(E.of(req.body)),
       // Create response
       E.map(
         TE.fold(
@@ -33,7 +34,7 @@ const handler =
 export const makeUploadToS3Router = (uploadToS3UseCase: UploadToS3UseCase): express.Router => {
   const router = express.Router();
 
-  router.put('/uploadS3/:key', toExpressHandler(handler(uploadToS3UseCase)));
+  router.put('/uploadS3/:key', express.raw({ type: 'application/pdf' }), toExpressHandler(handler(uploadToS3UseCase)));
 
   return router;
 };

--- a/src/domain/PreLoadRepository.ts
+++ b/src/domain/PreLoadRepository.ts
@@ -56,12 +56,15 @@ export const hasApplicationPdfAsContentType = (record: PreLoadRecord) =>
   );
 
 export const matchProperties =
-  (sha256: string, secret: string, key: string) =>
+  (sha256: string, secret: string, key: string, computedSha256: string) =>
   (record: PreLoadRecord): boolean =>
     record.output.statusCode === 200 &&
     pipe(
       RA.zip(record.output.returned)(record.input.body),
-      RA.exists(([body, response]) => body.sha256 === sha256 && response.secret === secret && response.key === key)
+      RA.exists(
+        ([body, response]) =>
+          body.sha256 === sha256 && response.secret === secret && response.key === key && body.sha256 === computedSha256
+      )
     );
 
 const existsPreLoadRecordWithSameSha256 = (sha256: string | undefined) => (record: PreLoadRecord) =>

--- a/src/domain/UploadToS3RecordRepository.ts
+++ b/src/domain/UploadToS3RecordRepository.ts
@@ -40,7 +40,12 @@ export const matchAnyPreLoadRecord =
       preLoadRecordList,
       RA.exists(
         // TODO: Add insert date and check that uploadToS3Record.createdAt is bigger than the one of preLoadRecord
-        matchProperties(uploadToS3Record.input.checksum, uploadToS3Record.input.secret, uploadToS3Record.input.key)
+        matchProperties(
+          uploadToS3Record.input.checksum,
+          uploadToS3Record.input.secret,
+          uploadToS3Record.input.key,
+          uploadToS3Record.input.computedSha256
+        )
       )
     );
 

--- a/src/domain/UploadToS3RecordRepository.ts
+++ b/src/domain/UploadToS3RecordRepository.ts
@@ -20,6 +20,7 @@ export type UploadToS3Record = {
     checksumAlg?: AmzSdkChecksumAlg;
     secret: AmzMetaSecret;
     checksum: AmzChecksumSHA256;
+    computedSha256: string;
   };
   output: Response<200, AmzVersionId>;
 };

--- a/src/domain/__tests__/PreLoadRepository.test.ts
+++ b/src/domain/__tests__/PreLoadRepository.test.ts
@@ -45,7 +45,12 @@ describe('PreLoadRepository', () => {
 
   describe('matchProperties', () => {
     it('should be true if properties have a match', () => {
-      const actual = matchProperties(data.aSha256, data.aSecret, data.anAttachmentRef.key)(data.preLoadRecord);
+      const actual = matchProperties(
+        data.aSha256,
+        data.aSecret,
+        data.anAttachmentRef.key,
+        data.aSha256
+      )(data.preLoadRecord);
       expect(actual).toStrictEqual(true);
     });
 
@@ -53,7 +58,8 @@ describe('PreLoadRepository', () => {
       const actual = matchProperties(
         data.aSha256,
         data.aSecret,
-        ''
+        '',
+        data.aSha256
       )({
         ...data.preLoadRecord,
         input: {

--- a/src/domain/__tests__/data.ts
+++ b/src/domain/__tests__/data.ts
@@ -162,6 +162,7 @@ export const uploadToS3Record: UploadToS3Record = {
     checksumAlg: undefined,
     secret: preLoadResponse.secret,
     checksum: preLoadBody.sha256,
+    computedSha256: preLoadBody.sha256,
   },
   output: { statusCode: 200, returned: parseInt(anAttachmentRef.versionToken, 10) },
 };

--- a/src/useCases/UploadToS3UseCase.ts
+++ b/src/useCases/UploadToS3UseCase.ts
@@ -1,3 +1,5 @@
+import crypto from 'crypto';
+import * as Buffer from 'buffer';
 import { pipe } from 'fp-ts/lib/function';
 import * as TE from 'fp-ts/TaskEither';
 import { AmzChecksumSHA256 } from '../generated/definitions/AmzChecksumSHA256';
@@ -7,13 +9,16 @@ import { AmzVersionId } from '../generated/definitions/AmzVersionId';
 import { AmzDocumentKey } from '../generated/definitions/AmzDocumentKey';
 import { SystemEnv } from './SystemEnv';
 
+const computeSha256 = (bytes: Buffer) => crypto.createHash('sha256').update(bytes).digest('base64');
+
 export const UploadToS3UseCase =
   ({ uploadToS3RecordRepository }: SystemEnv) =>
   (key: AmzDocumentKey) =>
   (checksumAlg?: AmzSdkChecksumAlg) =>
   (secret: AmzMetaSecret) =>
-  (checksum: AmzChecksumSHA256): TE.TaskEither<Error, AmzVersionId> => {
-    const input = { key, checksumAlg, secret, checksum };
+  (checksum: AmzChecksumSHA256) =>
+  (documentAsBytes: Buffer): TE.TaskEither<Error, AmzVersionId> => {
+    const input = { key, checksumAlg, secret, checksum, computedSha256: computeSha256(documentAsBytes) };
     const output = { statusCode: 200 as const, returned: Math.random() };
     return pipe(
       uploadToS3RecordRepository.insert({ type: 'UploadToS3Record', input, output }),


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
When the UploadToS3 request is made, the emulator now compute the SHA256 of the uploaded document and persists it.
It will be used to verify if the computed SHA is equals to the one provided previously in the PreLoad request.

#### List of Changes
<!--- Describe your changes in detail -->
- Compute SHA256 of the uploaded document
- Verify that the provided SHA matches the SHA computed

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Unit test

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
