### PR TITLE
[VL-161] - Increase limit size of uploaded document

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,4 +139,4 @@ docker run -p 3000:3000 pnemulator
 > Hint: The [Dockerfile](./Dockerfile) exposes the port `3000` of the container, so you can use the `-p` option to map it to a port of your choice.
 
 ### ADDITIONAL NOTES
-When you upload a document, the max allowed size of that document is 5MB. 
+When you upload a document, the max allowed size of that document is 100MB. 

--- a/README.md
+++ b/README.md
@@ -137,3 +137,6 @@ docker run -p 3000:3000 pnemulator
 ```
 
 > Hint: The [Dockerfile](./Dockerfile) exposes the port `3000` of the container, so you can use the `-p` option to map it to a port of your choice.
+
+### ADDITIONAL NOTES
+When you upload a document, the max allowed size of that document is 5MB. 

--- a/src/adapters/http/uploadToS3/router.ts
+++ b/src/adapters/http/uploadToS3/router.ts
@@ -35,7 +35,11 @@ const handler =
 export const makeUploadToS3Router = (uploadToS3UseCase: UploadToS3UseCase): express.Router => {
   const router = express.Router();
 
-  router.put('/uploadS3/:key', express.raw({ type: 'application/pdf' }), toExpressHandler(handler(uploadToS3UseCase)));
+  router.put(
+    '/uploadS3/:key',
+    express.raw({ type: 'application/pdf', limit: '5mb' }),
+    toExpressHandler(handler(uploadToS3UseCase))
+  );
 
   return router;
 };

--- a/src/adapters/http/uploadToS3/router.ts
+++ b/src/adapters/http/uploadToS3/router.ts
@@ -37,7 +37,7 @@ export const makeUploadToS3Router = (uploadToS3UseCase: UploadToS3UseCase): expr
 
   router.put(
     '/uploadS3/:key',
-    express.raw({ type: 'application/pdf', limit: '5mb' }),
+    express.raw({ type: 'application/pdf', limit: '100mb' }),
     toExpressHandler(handler(uploadToS3UseCase))
   );
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
Extend limit size of uploaded document from 100kB (default) to 5 MB.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The limit of 100kB size per file was too strict.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Using the file attached in [VL-161](https://pagopa.atlassian.net/browse/VL-161)

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
