### PR TITLE
VL-159 Add retry-after value

### DIFF
--- a/src/adapters/http/consumeEventStream/router.ts
+++ b/src/adapters/http/consumeEventStream/router.ts
@@ -20,7 +20,7 @@ export const consumeEventStreamHandler =
       E.map(
         TE.fold(
           (_) => T.of(res.status(500).send(Problem.fromNumber(500))),
-          (_) => T.of(res.status(_.statusCode).send(_.returned))
+          (_) => T.of(res.header(_.headers).status(_.statusCode).send(_.returned))
         )
       )
     );

--- a/src/domain/CheckNotificationStatusRecord.ts
+++ b/src/domain/CheckNotificationStatusRecord.ts
@@ -49,7 +49,10 @@ export const makeCheckNotificationStatusRecord =
                 t.exact(NewNotificationRequestStatusResponse).encode({ ...n, notificationRequestStatus: 'ACCEPTED' })
             )
           ),
-          O.map((response) => ({ statusCode: 200 as const, returned: response })),
+          O.map((response) => ({
+            statusCode: 200 as const,
+            returned: { ...response, retryAfter: env.retryAfterMs / 1000 },
+          })),
           O.getOrElseW(() => ({ statusCode: 404 as const, returned: undefined }))
         )
       )

--- a/src/domain/ConsumeEventStreamRecord.ts
+++ b/src/domain/ConsumeEventStreamRecord.ts
@@ -66,7 +66,7 @@ export const makeConsumeEventStreamRecord =
           // override the eventId to create a simple cursor based pagination
           RA.mapWithIndex((i, elem) => ({ ...elem, eventId: i.toString() })),
           RA.filterWithIndex((i) => i > parseInt(input.lastEventId || '-1', 10)),
-          (output) => ({ statusCode: 200 as const, returned: output })
+          (output) => ({ statusCode: 200 as const, headers: { 'retry-after': env.retryAfterMs }, returned: output })
         )
       )
     ),

--- a/src/domain/DomainEnv.ts
+++ b/src/domain/DomainEnv.ts
@@ -8,6 +8,7 @@ export type DomainEnv = {
   downloadDocumentURL: URL;
   sampleStaticPdfFileName: string;
   uploadToS3URL: URL;
+  retryAfterMs: number;
   // generators
   iunGenerator: IO<IUN>;
   dateGenerator: IO<Date>;

--- a/src/domain/__tests__/data.ts
+++ b/src/domain/__tests__/data.ts
@@ -85,6 +85,8 @@ export const aDocument1 = {
   },
 };
 
+export const aRetryAfterMs = 1000;
+
 export const makeTestSystemEnv = (
   createNotificationRequestRecords: ReadonlyArray<NewNotificationRecord> = [],
   findNotificationRequestRecords: ReadonlyArray<CheckNotificationStatusRecord> = [],
@@ -98,6 +100,7 @@ export const makeTestSystemEnv = (
     sampleStaticPdfFileName: 'sample.pdf',
     occurrencesAfterComplete: 2,
     senderPAId: aSenderPaId,
+    retryAfterMs: aRetryAfterMs,
     iunGenerator: () => aIun.valid,
     dateGenerator: () => new Date(0),
     recordRepository: inMemory.makeRecordRepository(logger)([
@@ -239,6 +242,7 @@ const checkNotificationStatusRecordReturned = {
   paProtocolNumber: paProtocolNumber.valid,
   notificationRequestId: notificationId.valid,
   notificationRequestStatus: 'WAITING',
+  retryAfter: aRetryAfterMs / 1000,
 };
 
 export const checkNotificationStatusRecord: CheckNotificationStatusRecord = {
@@ -325,6 +329,7 @@ export const inValidationEvent = {
 
 export const consumeEventStreamResponse = {
   statusCode: 200 as const,
+  headers: {'retry-after': aRetryAfterMs},
   returned: [
     {
       eventId: '0',

--- a/src/domain/__tests__/data.ts
+++ b/src/domain/__tests__/data.ts
@@ -329,7 +329,7 @@ export const inValidationEvent = {
 
 export const consumeEventStreamResponse = {
   statusCode: 200 as const,
-  headers: {'retry-after': aRetryAfterMs},
+  headers: { 'retry-after': aRetryAfterMs },
   returned: [
     {
       eventId: '0',

--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -10,6 +10,7 @@ export type UnauthorizedMessageBody = {
 
 export type Response<A extends StatusCode, B = void> = {
   statusCode: A;
+  headers?: Record<'retry-after', string | number>;
   returned: B;
 };
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -28,6 +28,7 @@ pipe(
     const systemEnv: SystemEnv = {
       occurrencesAfterComplete: 2, // TODO: occurrencesAfterComplete move this value into configuration
       senderPAId: 'aSenderPaId', // TODO: senderPaId move this value into configuration
+      retryAfterMs: 1000,
       downloadDocumentURL: config.server.downloadDocumentURL,
       sampleStaticPdfFileName: 'sample.pdf',
       iunGenerator: IUNGenerator,

--- a/src/useCases/__tests__/ConsumeEventStreamUseCase.test.ts
+++ b/src/useCases/__tests__/ConsumeEventStreamUseCase.test.ts
@@ -13,7 +13,7 @@ describe('ConsumeEventStreamUseCase', () => {
 
       const actual = await useCase(data.apiKey.valid)(data.streamId.valid)(undefined)();
 
-      expect(actual).toStrictEqual(E.right({ statusCode: 200 as const, returned: [] }));
+      expect(actual).toStrictEqual(E.right({ ...data.consumeEventStreamResponse, returned: [] }));
     });
     it('should return waiting status', async () => {
       const useCase = ConsumeEventStreamUseCase({


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Add the value `retry-after` and `retryAfter` returned by two endpoint ([/delivery/requests](https://petstore.swagger.io/?url=https://raw.githubusercontent.com/pagopa/pn-delivery/develop/docs/openapi/api-external-b2b-pa-v1.yaml#/SenderReadB2B/retrieveNotificationRequestStatus) and [/delivery-progresses/streams/{streamId}/events](https://petstore.swagger.io/?url=https://raw.githubusercontent.com/pagopa/pn-delivery-push/develop/docs/openapi/api-external-b2b-webhook-v1.yaml#/Events/consumeEventStream))

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Unit and e2e tests

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
