### PR TITLE
VL-227 Fix checks about legal facts

### DIFF
--- a/src/domain/checks/LegalFactDownloadMetadataChecks.ts
+++ b/src/domain/checks/LegalFactDownloadMetadataChecks.ts
@@ -43,10 +43,15 @@ export const getLegalFactDownloadMetadataRecord = pipe(
   R.map(({ legalFactDownloadMetadataRecordList, getNotificationDetailRecordList }) =>
     pipe(
       legalFactDownloadMetadataRecordList,
-      RA.every((legalFactDownloadMetadataRecord) =>
-        pipe(
-          getNotificationDetailRecordList,
-          RA.exists(matchesLegalFactDownloadMetadataRecordC(legalFactDownloadMetadataRecord))
+      pipe(
+        RA.isNonEmpty,
+        P.and(
+          RA.every((legalFactDownloadMetadataRecord) =>
+            pipe(
+              getNotificationDetailRecordList,
+              RA.exists(matchesLegalFactDownloadMetadataRecordC(legalFactDownloadMetadataRecord))
+            )
+          )
         )
       )
     )

--- a/src/domain/checks/__tests__/LegalFactDownloadMetadataChecks.test.ts
+++ b/src/domain/checks/__tests__/LegalFactDownloadMetadataChecks.test.ts
@@ -22,7 +22,7 @@ describe('LegalFactDownloadMetadataChecks', () => {
       check([data.getLegalFactDownloadMetadataRecord, data.getNotificationDetailRecordAcceptedWithTimeline])
     ).toStrictEqual(true);
 
-    // If no legal facts are present, the check should be true
-    expect(check([])).toStrictEqual(true);
+    // If no legal facts are present, the check should be false
+    expect(check([])).toStrictEqual(false);
   });
 });


### PR DESCRIPTION
Before this PR, even if no calls have been made, tests for legal facts return always true. After this PR, given the same initial conditions, the checks return the value false.

<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The checks `Have you downloaded the PDF of the legal facts?` and `Have you requested the metadata of the legal facts?` are always true, even if no calls have been made.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Unit Tests.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
