### PR TITLE
VL-226 Fix issue on GetNotificationPriceRecordChecks

### DIFF
--- a/src/domain/checks/GetNotificationPriceRecordChecks.ts
+++ b/src/domain/checks/GetNotificationPriceRecordChecks.ts
@@ -21,10 +21,13 @@ export const atLeastOneGetNotificationPriceRecordMatchingPreviousNotificationReq
             pipe(
               getNotificationPriceRecordList,
               RA.exists(
-                ({ input: { paTaxId, noticeCode } }) =>
+                ({ input: { paTaxId, noticeCode }, output }) =>
                   payment?.creditorTaxId === paTaxId &&
                   payment?.creditorTaxId === record.input.body.senderTaxId &&
-                  payment.noticeCode === noticeCode
+                  payment.noticeCode === noticeCode &&
+                  // Without this check, the system accepts requests
+                  // that result in an unauthorized response.
+                  output.statusCode === 200
               )
             )
           )

--- a/src/domain/checks/__tests__/GetNotificationPriceRecordChecks.test.ts
+++ b/src/domain/checks/__tests__/GetNotificationPriceRecordChecks.test.ts
@@ -1,11 +1,12 @@
 import * as GetNotificationPriceRecordChecks from '../GetNotificationPriceRecordChecks';
 import * as data from '../../__tests__/data';
+import { unauthorizedResponse } from '../../types';
 
 const ex0 = [data.preLoadRecord, data.preLoadRecord, data.uploadToS3Record];
 const ex1 = [...ex0, data.getNotificationPriceRecord];
 const ex2 = [data.getNotificationPriceRecord, data.newNotificationRecord];
 const ex3 = [
-  data.getNotificationPriceRecord,
+  { ...data.getNotificationPriceRecord, output: unauthorizedResponse },
   data.mkNewNotificationRecord(
     [data.aDocument0],
     [
@@ -18,6 +19,7 @@ const ex3 = [
     ]
   ),
 ];
+const ex4 = [...ex3, data.getNotificationPriceRecord];
 
 describe('GetNotificationPriceRecordChecks', () => {
   it('atLeastOneGetNotificationPriceRecordC', () => {
@@ -33,6 +35,7 @@ describe('GetNotificationPriceRecordChecks', () => {
     expect(check(ex0)).toStrictEqual(false);
     expect(check(ex1)).toStrictEqual(false);
     expect(check(ex2)).toStrictEqual(false);
-    expect(check(ex3)).toStrictEqual(true);
+    expect(check(ex3)).toStrictEqual(false);
+    expect(check(ex4)).toStrictEqual(true);
   });
 });


### PR DESCRIPTION
Before this PR, the check "Have you provided the payment details from the notice previously created?" was true even if the system returned a failed response requesting the price of the notification. After this PR, the check returns true only if the notification price request returns successful responses.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The check "Have you provided the payment details from the notice previously created?" was true even if the system returned a failed response requesting the price of the notification.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Unit tests.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
