### PR TITLE
PN-19084: pin trivy-action

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -57,7 +57,7 @@ jobs:
           tags: ${{ env.image_tag }}
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.7.1
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 #v0.35.0
         with:
           image-ref: ${{ env.image_tag }}
           format: 'sarif'


### PR DESCRIPTION
La PR imposta una versione "pinned" della gh action trivy-action in quanto il tag utilizzato risultava compromesso.